### PR TITLE
Dev satu => dev

### DIFF
--- a/asm/src/generate/asm_get_param_sizes.c
+++ b/asm/src/generate/asm_get_param_sizes.c
@@ -24,34 +24,10 @@ t_astnode *parameter_list)
 	}
 }
 
-// lhs, rhs, dst
-// ldi, lldi, and, or, xor
-// ld?
-
-static void	asm_promote_param_size(t_astnode *lhs, t_astnode *rhs,
-int *lhs_size, int *rhs_size)
-{
-	int	lhs_type_size;
-	int	rhs_type_size;
-
-	lhs_type_size = *lhs_size;
-	rhs_type_size = *rhs_size;
-	if (lhs->type == REGISTER)
-		lhs_type_size = REG_SIZE;
-	if (rhs->type == REGISTER)
-		rhs_type_size = REG_SIZE;
-	if (lhs_type_size < rhs_type_size && lhs->type == DIRECT)
-		*lhs_size = rhs_type_size;
-	else if (rhs_type_size < lhs_type_size && rhs->type == DIRECT)
-		*rhs_size = lhs_type_size;
-}
-
 void	asm_get_param_sizes(int param_sizes[3], t_astnode *instruction_node,
 t_astnode *parameter_list)
 {
 	t_op		instruction;
-	t_astnode	*lhs_param;
-	t_astnode	*rhs_param;
 
 	asm_set_default_param_sizes(param_sizes, parameter_list);
 	asm_get_instruction(&instruction, instruction_node->value);
@@ -63,9 +39,9 @@ t_astnode *parameter_list)
 		|| s_cmp(instruction.mnemonic, "xor") == 0
 		|| s_cmp(instruction.mnemonic, "ld") == 0)
 	{
-		lhs_param = parameter_list->left_child;
-		rhs_param = parameter_list->right_child->left_child;
-		asm_promote_param_size(lhs_param, rhs_param,
-			&param_sizes[0], &param_sizes[1]);
+		if (parameter_list->left_child->type == DIRECT)
+			param_sizes[0] = REG_SIZE;
+		if (parameter_list->right_child->left_child->type == DIRECT)
+			param_sizes[1] = REG_SIZE;
 	}
 }

--- a/test/test_diff.sh
+++ b/test/test_diff.sh
@@ -7,7 +7,7 @@ user_asm="../bin/asm"
 user_corewar="../bin/corewar"
 
 ## Verbosity level for vm: from 0 to 31
-vm_verbosity="0"
+vm_verbosity="31"
 
 ## Path to the player .cor file is taken as the first command line argument
 
@@ -84,7 +84,7 @@ run_vm() {
 	local player_cor=$2
 	local output_file=$3
 
-	echo "$corewar $player_cor -d $cycles_to_run -v $vm_verbosity >$output_file 2>&1"
+	echo "$corewar -d $cycles_to_run -v $vm_verbosity $player_cor >$output_file 2>&1"
 	$corewar $player_cor -d $cycles_to_run -v $vm_verbosity >$output_file 2>&1
 	exit_status=$?
 	if [ $exit_status != 0 ]; then
@@ -96,7 +96,7 @@ echo
 echo "with subject vm..."
 subject_player_cor="$outdir_subject/$player.cor"
 subject_corewar_output_file="$outdir_subject/subject_corewar_output_$player"
-run_vm $subject_corewar $subject_player_cor $subject_corewar_output_file
+run_vm $subject_corewar "-a $subject_player_cor" $subject_corewar_output_file
 
 echo
 echo "with user vm..."

--- a/test/test_instructions/test_aff.s
+++ b/test/test_instructions/test_aff.s
@@ -15,20 +15,20 @@ aff r2			; 0
 # load character values in registers; assumes load works
 # and that REG_NUMBER is 16
 
-ld 42 r3		; '*'
-ld 48 r4		; '0'
-ld 49 r5		; '1'
-ld 50 r6		; '2'
-ld 65 r7		; 'A'
-ld 66 r8		; 'B'
-ld 67 r9		; 'C'
-ld 42 r10		; '4'
-ld 42 r11		; '2'
-ld 42 r12		; '\n'
-ld 42 r13		; ' '
-ld 123 r14		; '{' 
-ld 124 r15		; '|'
-ld 125 r16		; '}'
+ld %42, r3		; '*'
+ld %48, r4		; '0'
+ld %49, r5		; '1'
+ld %50, r6		; '2'
+ld %65, r7		; 'A'
+ld %66, r8		; 'B'
+ld %67, r9		; 'C'
+ld %42, r10		; '4'
+ld %42, r11		; '2'
+ld %42, r12		; '\n'
+ld %42, r13		; ' '
+ld %123, r14		; '{' 
+ld %124, r15		; '|'
+ld %125, r16		; '}'
 
 aff r3
 aff r4

--- a/test/test_instructions/test_and.s
+++ b/test/test_instructions/test_and.s
@@ -1,0 +1,53 @@
+.name "TEST_and"
+.comment "test and instruction!!!!!"
+
+# and lhs, rhs, dst
+
+# Computes lhs & rhs and stores the result in register dst
+# Result affects zf
+
+# x cycles
+
+# { T_REG | T_IND | T_DIR, T_REG | T_IND | T_DIR, T_REG }
+
+and r2, r4, r4
+and r2, r4, r5
+and r1, r1, r1
+and r10, r15, r16
+and r8, r12, r3
+
+and %2, r4, r4
+and %2, r4, r5
+and %1, r1, r1
+and %10, r15, r16
+and %8, r12, r3
+
+and r2, %4, r4
+and r2, %4, r5
+and r1, %4, r1
+and r10,%4, r16
+and r8, %4, r3
+
+and %2, %4, r4
+and %2, %4, r5
+and %1, %4, r1
+and %10,%4, r16
+and %8, %4, r3
+
+and 2, %4, r4
+and 2, %4, r5
+and 1, %4, r1
+and 10,%4, r16
+and 8, %4, r3
+
+and %2, 4, r4
+and %2, 4, r5
+and %1, 4, r1
+and %10,4, r16
+and %8, 4, r3
+
+and 2, 4, r4
+and 2, 4, r5
+and 1, 4, r1
+and 10,4, r16
+and 8, 4, r3

--- a/vm/Makefile
+++ b/vm/Makefile
@@ -62,7 +62,8 @@ SRC_BASE	=	vm_main.c \
 				vm_instr_or.c \
 				vm_instr_xor.c \
 				vm_advance_pc.c \
-				vm_pause_and_print_memory.c
+				vm_pause_and_print_memory.c \
+				vm_print_bytes.c
 
 SRC			=	$(addprefix $(SRC_DIR), $(SRC_BASE))
 OBJ			=	$(addprefix $(OBJ_DIR), $(SRC_BASE:.c=.o))

--- a/vm/Makefile
+++ b/vm/Makefile
@@ -41,6 +41,7 @@ SRC_BASE	=	vm_main.c \
 				vm_get_mem_addr.c \
 				vm_get_reg_addr.c \
 				vm_get_arg_data.c \
+				vm_get_arg_type.c \
 				vm_get_val.c \
 				vm_instr_null.c \
 				vm_instr_live.c \

--- a/vm/inc/vm.h
+++ b/vm/inc/vm.h
@@ -27,7 +27,7 @@
 # define VM_PRINT_ARENA_WIDTH	64
 
 typedef t_byte* t_mem_addr;
-typedef t_int64* t_reg_addr;
+typedef t_byte* t_reg_addr;
 typedef struct s_argument
 {
 	t_int64 value;
@@ -51,7 +51,7 @@ typedef struct s_process
 	t_bool				zf;
 
 	// 32 bit registers 1 - 16, r1 initialized at player ID and the rest at 0
-	t_int64				registers[REG_NUMBER];
+	t_byte				registers[REG_NUMBER][REG_SIZE];
 	struct s_process	*next;
 }	t_process;
 
@@ -118,7 +118,7 @@ void	vm_create_player(
 t_process	*vm_create_process(
 		t_arena arena,
 		t_process *process_lst,
-		t_uint64 player_id);
+		t_int32 player_id);
 
 void	*vm_reverse_bytes(
 		void *dst,
@@ -250,12 +250,15 @@ t_int64	vm_get_val(
 void	vm_advance_pc(
 		t_size *pc,
 		int size,
+		t_byte *mem,
 		int verbosity);
 
 t_uint8	vm_get_arg_size(
 		t_uint8 opcode,
 		t_uint8 arg_nbr,
 		t_uint8 acb);
+
+void	vm_print_bytes(void *memory, size_t len);
 
 static const t_instr g_instr_funcs[] =
 {

--- a/vm/inc/vm.h
+++ b/vm/inc/vm.h
@@ -27,7 +27,7 @@
 # define VM_PRINT_ARENA_WIDTH	64
 
 typedef t_byte* t_mem_addr;
-typedef t_uint64* t_reg_addr;
+typedef t_int64* t_reg_addr;
 typedef struct s_argument
 {
 	t_int64 value;
@@ -43,7 +43,6 @@ typedef struct s_process
 	t_int32				last_live;
 	t_int32				cycles_before_execution;
 	// Program counter.
-	// t_byte			*pc;
 	t_size				pc;
 
 	// Zero flag, Along with a carry flag, a sign flag and an overflow flag,
@@ -52,7 +51,7 @@ typedef struct s_process
 	t_bool				zf;
 
 	// 32 bit registers 1 - 16, r1 initialized at player ID and the rest at 0
-	t_uint64			registers[16];
+	t_int64				registers[REG_NUMBER];
 	struct s_process	*next;
 }	t_process;
 
@@ -99,17 +98,19 @@ typedef struct s_input_args
 
 typedef void (*t_instr)(t_arena *, t_process *);
 
-void vm_error(
+void	vm_error(
 		const char *message);
 
-void vm_save_input(
+void	vm_save_input(
 		t_arena *arena,
 		t_uint32 argc,
 		char **argv);
 
-t_input_args	vm_parse_arguments(int argc, char **argv);
+t_input_args	vm_parse_arguments(
+	int argc,
+	char **argv);
 
-void vm_create_player(
+void	vm_create_player(
 		t_arena *arena,
 		t_int32 *player_number,
 		char *name);
@@ -119,103 +120,103 @@ t_process	*vm_create_process(
 		t_process *process_lst,
 		t_uint64 player_id);
 
-void *vm_reverse_bytes(
+void	*vm_reverse_bytes(
 		void *dst,
 		void *src,
 		t_size size);
 
-void vm_check_live(
+void	vm_check_live(
 		t_process **processes,
 		t_arena *arena);
 
-void vm_execute_cycle(
+void	vm_execute_cycle(
 		t_process *processes,
 		t_arena *arena);
 
-void vm_introduce_champs(
+void	vm_introduce_champs(
 		t_arena arena);
 
 void	vm_pause_and_print_memory(
 		t_arena arena);
 
-void vm_test_print_arena(
+void	vm_test_print_arena(
 		t_arena arena);
 
-void vm_test_print_processes(
+void	vm_test_print_processes(
 		t_process *lst);
 
-void vm_battle(
+void	vm_battle(
 		t_arena arena);
 
-void vm_print_arena(
+void	vm_print_arena(
 		t_arena arena,
 		t_process *process_list);
 
-void vm_instr_live(
+void	vm_instr_live(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_add(
+void	vm_instr_add(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_sub(
+void	vm_instr_sub(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_and(
+void	vm_instr_and(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_or(
+void	vm_instr_or(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_xor(
+void	vm_instr_xor(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_ld(
+void	vm_instr_ld(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_st(
+void	vm_instr_st(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_zjmp(
+void	vm_instr_zjmp(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_ldi(
+void	vm_instr_ldi(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_sti(
+void	vm_instr_sti(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_fork(
+void	vm_instr_fork(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_lld(
+void	vm_instr_lld(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_lldi(
+void	vm_instr_lldi(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_lfork(
+void	vm_instr_lfork(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_aff(
+void	vm_instr_aff(
 		t_arena *a,
 		t_process *p);
 
-void vm_instr_null(
+void	vm_instr_null(
 		t_arena *a,
 		t_process *p);
 
@@ -227,11 +228,11 @@ t_uint8	vm_get_arg_type(
 		t_uint8 acb,
 		t_size arg_i);
 
-t_reg_addr vm_get_reg_addr(
+t_reg_addr	vm_get_reg_addr(
 		t_process *p,
 		t_size i);
 
-t_mem_addr vm_get_mem_addr(
+t_mem_addr	vm_get_mem_addr(
 		t_arena *a,
 		t_size i);
 
@@ -240,7 +241,7 @@ t_argument	vm_get_arg_data(
 		t_uint8 opcode,
 		t_uint8 arg_i);
 
-t_int64 vm_get_val(
+t_int64	vm_get_val(
 	t_arena *a,
 		t_process *p,
 		t_argument arg,
@@ -248,7 +249,8 @@ t_int64 vm_get_val(
 
 void	vm_advance_pc(
 		t_size *pc,
-		int size);
+		int size,
+		int verbosity);
 
 t_uint8	vm_get_arg_size(
 		t_uint8 opcode,

--- a/vm/src/vm_advance_pc.c
+++ b/vm/src/vm_advance_pc.c
@@ -1,6 +1,11 @@
 #include "vm.h"
 
-void	vm_advance_pc(t_size *pc, int size)
+void	vm_advance_pc(t_size *pc, int size, int verbosity)
 {
+	t_size	new_pc;
+
+	new_pc = (*pc + size) % MEM_SIZE;
+	if ((verbosity & VM_VERBOSE_PC) != 0)
+		print("\t\tPC: %d => %d\n", (int)*pc, (int)new_pc);
 	*pc = (*pc + size) % MEM_SIZE;
 }

--- a/vm/src/vm_advance_pc.c
+++ b/vm/src/vm_advance_pc.c
@@ -1,11 +1,21 @@
 #include "vm.h"
 
-void	vm_advance_pc(t_size *pc, int size, int verbosity)
+void	vm_advance_pc(t_size *pc, int size, t_byte *mem, int verbosity)
 {
 	t_size	new_pc;
 
 	new_pc = (*pc + size) % MEM_SIZE;
 	if ((verbosity & VM_VERBOSE_PC) != 0)
-		print("\t\tPC: %d => %d\n", (int)*pc, (int)new_pc);
+	{
+		print("\t\tPC: %#06x => %#06x\t", (int)*pc, (int)new_pc);
+		if (size > 0)
+			vm_print_bytes(&mem[*pc], size);
+		else
+		{
+			vm_print_bytes(&mem[*pc], MEM_SIZE - *pc);
+			vm_print_bytes(&mem[0], size + *pc);
+		}
+		print("\n");
+	}
 	*pc = (*pc + size) % MEM_SIZE;
 }

--- a/vm/src/vm_battle.c
+++ b/vm/src/vm_battle.c
@@ -41,7 +41,6 @@ void	vm_battle(t_arena arena)
 		vm_execute_cycle(arena.processes, &arena);
 		while (++arena.cycles_since_check < arena.cycle_to_die)
 		{
-			vm_execute_cycle(arena.processes, &arena);
 			if (arena.dump_nbr_cycles && 
 			arena.current_cycle > arena.dump_nbr_cycles)
 			{
@@ -49,6 +48,7 @@ void	vm_battle(t_arena arena)
 				vm_free_processes(&arena.processes);
 				return ;
 			}
+			vm_execute_cycle(arena.processes, &arena);
 			if (arena.pause_nbr_cycles
 				&& arena.current_cycle + 1 % arena.pause_nbr_cycles)
 				vm_pause_and_print_memory(arena);

--- a/vm/src/vm_check_acb.c
+++ b/vm/src/vm_check_acb.c
@@ -4,16 +4,6 @@
 // which argument is in question. Masks that part from the acb and
 // shifts the results to the least significant bit.
 
-t_uint8	vm_get_arg_type(
-		t_uint8 acb,
-		t_size arg_i)
-{
-	t_uint8	mask;
-
-	mask = 0b11000000 >> (arg_i * 2);
-	return ((acb & mask) >> (6 - (arg_i * 2)));
-}
-
 t_uint8 vm_check_acb(
 		t_uint8 acb,
 		t_size op)
@@ -21,12 +11,21 @@ t_uint8 vm_check_acb(
 	t_param_types arg;
 
 	arg = g_op_tab[op - 1].param_types;
-	print("op %s", g_op_tab[op - 1].description);
+	//print("op %s", g_op_tab[op - 1].description);
 	if ((vm_get_arg_type(acb, 0) & arg.param1) == 0 && arg.param1)
+	{
 		print("acb %d does not match arg1 %d\n", vm_get_arg_type(acb, 0), arg.param1);
+		return (0);
+	}
 	if ((vm_get_arg_type(acb, 1) & arg.param2) == 0 && arg.param2)
+	{
 		print("acb does not match arg2\n");
+		return (0);
+	}
 	if ((vm_get_arg_type(acb, 2) & arg.param3) == 0 && arg.param3)
+	{
 		print("acb does not match arg3\n");
-	return(1);
+		return (0);
+	}
+	return (1);
 }

--- a/vm/src/vm_create_process.c
+++ b/vm/src/vm_create_process.c
@@ -5,7 +5,7 @@
 */
 
 t_process	*vm_create_process(t_arena arena, t_process *process_lst, \
-t_uint64 player_id)
+t_int32 player_id)
 {
 	t_process	*new_process;
 
@@ -13,9 +13,8 @@ t_uint64 player_id)
 	if (!new_process)
 		vm_error("Malloc failed in create_process\n");
 	new_process->id = player_id;
-	new_process->registers[0] = player_id;
+	vm_reverse_bytes(new_process->registers[0], &player_id, REG_SIZE);
 	new_process->pc = (player_id - 1) * arena.offset;
-//	new_process->pc = &arena.mem[MEM_SIZE / arena.player_count * player_id];
 	new_process->cycles_before_execution = -1;
 	new_process->next = process_lst;
 	return (new_process);

--- a/vm/src/vm_execute_cycle.c
+++ b/vm/src/vm_execute_cycle.c
@@ -31,11 +31,11 @@ void	vm_init_instruction_execution(t_process *process, t_arena *arena)
 
 	instruction = vm_get_instruction(arena->mem[process->pc]);
 	if (instruction.mnemonic == 0)
-		vm_advance_pc(&process->pc, 1);
+		vm_advance_pc(&process->pc, 1, 0);
 	else
 	{
 		process->current_instruction = instruction;
-		process->cycles_before_execution = instruction.cycles - 2;
+		process->cycles_before_execution = instruction.cycles;
 	}
 }
 
@@ -47,12 +47,12 @@ void	vm_finish_instruction_execution(t_process *process, t_arena *arena)
 
 void	vm_execute_process(t_process *process, t_arena *arena)
 {
+	if (process->cycles_before_execution == -1)
+		vm_init_instruction_execution(process, arena);
 	if (process->cycles_before_execution > 0)
 		process->cycles_before_execution--;
-	else if (process->cycles_before_execution == 0)
+	if (process->cycles_before_execution == 0)
 		vm_finish_instruction_execution(process, arena);
-	else
-		vm_init_instruction_execution(process, arena);
 }
 
 void	vm_execute_cycle(t_process *process, t_arena *arena)

--- a/vm/src/vm_execute_cycle.c
+++ b/vm/src/vm_execute_cycle.c
@@ -31,7 +31,7 @@ void	vm_init_instruction_execution(t_process *process, t_arena *arena)
 
 	instruction = vm_get_instruction(arena->mem[process->pc]);
 	if (instruction.mnemonic == 0)
-		vm_advance_pc(&process->pc, 1, 0);
+		vm_advance_pc(&process->pc, 1, arena->mem, 0);
 	else
 	{
 		process->current_instruction = instruction;

--- a/vm/src/vm_get_arg_data.c
+++ b/vm/src/vm_get_arg_data.c
@@ -22,7 +22,7 @@ t_uint8	vm_get_arg_size(
 	else if (vm_get_arg_type(acb, arg_nbr) == DIR_CODE)
 		return (DIR_VAL_SIZE);
 	else if (vm_get_arg_type(acb, arg_nbr) == IND_CODE)
-		return (IND_CODE);
+		return (IND_ADDR_SIZE);
 	else
 		return (REG_SIZE);
 }
@@ -36,5 +36,6 @@ t_argument	vm_get_arg_data(
 
 	arg.type = vm_get_arg_type(acb, arg_i);
 	arg.size = vm_get_arg_size(acb, opcode, arg_i);
+	//print("arg type %d, size %d\n", arg.type, arg.size);
 	return (arg);
 }

--- a/vm/src/vm_get_arg_type.c
+++ b/vm/src/vm_get_arg_type.c
@@ -1,0 +1,11 @@
+#include "vm.h"
+
+t_uint8	vm_get_arg_type(
+		t_uint8 acb,
+		t_size arg_i)
+{
+	t_uint8	mask;
+
+	mask = 0b11000000 >> (arg_i * 2);
+	return ((acb & mask) >> (6 - (arg_i * 2)));
+}

--- a/vm/src/vm_get_reg_addr.c
+++ b/vm/src/vm_get_reg_addr.c
@@ -4,9 +4,9 @@ t_reg_addr vm_get_reg_addr(
 		t_process *p,
 		t_size i)
 {
-	if (i < 1 || i > 16)
+	if (i < 1 || i > REG_NUMBER)
 	{
-		print("Reg out of bounds!\n");
+		print("Reg %d out of bounds!\n", (int)i);
 		return (NULL);
 	}
 	return (&p->registers[i - 1]);

--- a/vm/src/vm_get_reg_addr.c
+++ b/vm/src/vm_get_reg_addr.c
@@ -9,5 +9,5 @@ t_reg_addr vm_get_reg_addr(
 		print("Reg %d out of bounds!\n", (int)i);
 		return (NULL);
 	}
-	return (&p->registers[i - 1]);
+	return (p->registers[i - 1]);
 }

--- a/vm/src/vm_get_val.c
+++ b/vm/src/vm_get_val.c
@@ -16,7 +16,7 @@ t_int64	vm_get_val(
 	{
 		vm_reverse_bytes(&arg.value,
 		vm_get_mem_addr(a, a->mem[*mem_i]), IND_ADDR_SIZE);
-		*mem_i = (*mem_i + REG_ADDR_SIZE) % MEM_SIZE;
+		*mem_i = (*mem_i + IND_ADDR_SIZE) % MEM_SIZE;
 	}
 	else
 	{

--- a/vm/src/vm_get_val.c
+++ b/vm/src/vm_get_val.c
@@ -6,6 +6,8 @@ t_int64	vm_get_val(
 		t_argument arg,
 		t_size *mem_i)
 {
+	t_int16	index;
+
 	if (arg.type == T_REG)
 	{
 		vm_reverse_bytes(&arg.value, vm_get_reg_addr(p, a->mem[*mem_i]),
@@ -14,8 +16,8 @@ t_int64	vm_get_val(
 	}
 	else if (arg.type == IND_CODE)
 	{
-		vm_reverse_bytes(&arg.value,
-		vm_get_mem_addr(a, a->mem[*mem_i]), IND_ADDR_SIZE);
+		vm_reverse_bytes(&index, &a->mem[*mem_i], IND_ADDR_SIZE);
+		vm_reverse_bytes(&arg.value, vm_get_mem_addr(a, (p->pc + index) % MEM_SIZE), REG_SIZE);
 		*mem_i = (*mem_i + IND_ADDR_SIZE) % MEM_SIZE;
 	}
 	else

--- a/vm/src/vm_instr_aff.c
+++ b/vm/src/vm_instr_aff.c
@@ -20,14 +20,14 @@ void	vm_instr_aff(
 	acb = a->mem[mem_i];
 	if (!vm_check_acb(acb, p->current_instruction.opcode))
 	{
-		vm_advance_pc(&p->pc, 1, a->verbosity);
+		vm_advance_pc(&p->pc, 1, a->mem, a->verbosity);
 		return ;
 	}
 	mem_i = (mem_i + 1) % MEM_SIZE;
 	reg = vm_get_reg_addr(p, mem_i);
 	if (reg == NULL)
 	{
-		vm_advance_pc(&p->pc, 1, a->verbosity);
+		vm_advance_pc(&p->pc, 1, a->mem, a->verbosity);
 		return ;
 	}
 	out = (char)*reg;
@@ -35,5 +35,5 @@ void	vm_instr_aff(
 		print("\t\taff %c\n", out);
 	print("Aff: %c\n", out);
 	mem_i = (mem_i + REG_ADDR_SIZE) % MEM_SIZE;
-	vm_advance_pc(&p->pc, mem_i - p->pc, a->verbosity);
+	vm_advance_pc(&p->pc, mem_i - p->pc, a->mem, a->verbosity);
 }

--- a/vm/src/vm_instr_aff.c
+++ b/vm/src/vm_instr_aff.c
@@ -9,19 +9,31 @@ void	vm_instr_aff(
 		t_arena *a,
 		t_process *p)
 {
-	t_size	mem_i;
-	char	out;
+	t_size		mem_i;
+	t_uint8		acb;
+	t_reg_addr	reg;
+	char		out;
 
 	if ((a->verbosity & VM_VERBOSE_OPS) != 0)
-		print("\t%s\n", "aff chr");
+		print("\t\t%s\n", "aff chr");
 	mem_i = (p->pc + 1) % MEM_SIZE;
+	acb = a->mem[mem_i];
+	if (!vm_check_acb(acb, p->current_instruction.opcode))
+	{
+		vm_advance_pc(&p->pc, 1, a->verbosity);
+		return ;
+	}
 	mem_i = (mem_i + 1) % MEM_SIZE;
-	out = (char)*vm_get_reg_addr(p, mem_i);
+	reg = vm_get_reg_addr(p, mem_i);
+	if (reg == NULL)
+	{
+		vm_advance_pc(&p->pc, 1, a->verbosity);
+		return ;
+	}
+	out = (char)*reg;
 	if ((a->verbosity & VM_VERBOSE_OPS) != 0)
-		print("\taff %c\n", out);
-	print("%c", out);
-	mem_i += REG_ADDR_SIZE % MEM_SIZE;
-	if ((a->verbosity & VM_VERBOSE_PC) != 0)
-		print("\tPC: %d => %d\n", (int)p->pc, (int)mem_i);
-	p->pc = mem_i;
+		print("\t\taff %c\n", out);
+	print("Aff: %c\n", out);
+	mem_i = (mem_i + REG_ADDR_SIZE) % MEM_SIZE;
+	vm_advance_pc(&p->pc, mem_i - p->pc, a->verbosity);
 }

--- a/vm/src/vm_instr_and.c
+++ b/vm/src/vm_instr_and.c
@@ -10,24 +10,35 @@ void vm_instr_and(
 	t_int64		lhs;
 	t_int64		rhs;
 
-	// acb
+	if ((a->verbosity & VM_VERBOSE_OPS) != 0)
+		print("\t\t%s\n", "and lhs, rhs, dst");
 	mem_i = (p->pc + 1) % MEM_SIZE;
 	acb = a->mem[mem_i];
-
-	// arg 1
-	lhs = vm_get_val(a, p, vm_get_arg_data(acb, 6, 1), &mem_i);
-
-	// arg 2
-	rhs = vm_get_val(a, p, vm_get_arg_data(acb, 6, 2), &mem_i);
-
-	// arg 3
+	if (!vm_check_acb(acb, p->current_instruction.opcode))
+	{
+		vm_advance_pc(&p->pc, 1, a->verbosity);
+		return ;
+	}
+	mem_i = (mem_i + 1) % MEM_SIZE;
+	lhs = vm_get_val(a, p, vm_get_arg_data(acb, p->current_instruction.opcode, 0), &mem_i);
+	rhs = vm_get_val(a, p, vm_get_arg_data(acb, p->current_instruction.opcode, 1), &mem_i);
 	dst = vm_get_reg_addr(p, a->mem[mem_i]);
-
+	if (dst == NULL)
+	{
+		vm_advance_pc(&p->pc, 1, a->verbosity);
+		return ;
+	}
+	if ((a->verbosity & VM_VERBOSE_OPS) != 0)
+	{
+		print("\t\t%d & %d = %d to r%d\n",
+			(int)lhs, (int)rhs, (int)(lhs & rhs), a->mem[mem_i]);
+	}
 	*dst = lhs & rhs;
 	if (*dst == 0)
 		p->zf = 1;
 	else
 		p->zf = 0;
 	vm_reverse_bytes(dst, dst, REG_SIZE);
-	p->pc = mem_i + 1;
+	mem_i = (mem_i + 1) % MEM_SIZE;
+	vm_advance_pc(&p->pc, mem_i - p->pc, a->verbosity);
 }

--- a/vm/src/vm_instr_and.c
+++ b/vm/src/vm_instr_and.c
@@ -9,6 +9,7 @@ void vm_instr_and(
 	t_reg_addr	dst;
 	t_int64		lhs;
 	t_int64		rhs;
+	t_int64		result;
 
 	if ((a->verbosity & VM_VERBOSE_OPS) != 0)
 		print("\t\t%s\n", "and lhs, rhs, dst");
@@ -16,7 +17,7 @@ void vm_instr_and(
 	acb = a->mem[mem_i];
 	if (!vm_check_acb(acb, p->current_instruction.opcode))
 	{
-		vm_advance_pc(&p->pc, 1, a->verbosity);
+		vm_advance_pc(&p->pc, 1, a->mem, a->verbosity);
 		return ;
 	}
 	mem_i = (mem_i + 1) % MEM_SIZE;
@@ -25,7 +26,7 @@ void vm_instr_and(
 	dst = vm_get_reg_addr(p, a->mem[mem_i]);
 	if (dst == NULL)
 	{
-		vm_advance_pc(&p->pc, 1, a->verbosity);
+		vm_advance_pc(&p->pc, 1, a->mem, a->verbosity);
 		return ;
 	}
 	if ((a->verbosity & VM_VERBOSE_OPS) != 0)
@@ -33,12 +34,12 @@ void vm_instr_and(
 		print("\t\t%d & %d = %d to r%d\n",
 			(int)lhs, (int)rhs, (int)(lhs & rhs), a->mem[mem_i]);
 	}
-	*dst = lhs & rhs;
+	result = lhs & rhs;
+	vm_reverse_bytes(dst, &result, REG_SIZE);
 	if (*dst == 0)
 		p->zf = 1;
 	else
 		p->zf = 0;
-	vm_reverse_bytes(dst, dst, REG_SIZE);
 	mem_i = (mem_i + 1) % MEM_SIZE;
-	vm_advance_pc(&p->pc, mem_i - p->pc, a->verbosity);
+	vm_advance_pc(&p->pc, mem_i - p->pc, a->mem, a->verbosity);
 }

--- a/vm/src/vm_instr_sti.c
+++ b/vm/src/vm_instr_sti.c
@@ -30,7 +30,7 @@ void vm_instr_sti(
 	src = vm_get_reg_addr(p, a->mem[mem_i]);
 	if (!src)
 	{
-		vm_advance_pc(&p->pc, 1, a->verbosity);
+		vm_advance_pc(&p->pc, 1, a->mem, a->verbosity);
 		return ;
 	}
 	mem_i = (mem_i + 1) % MEM_SIZE;

--- a/vm/src/vm_instr_sti.c
+++ b/vm/src/vm_instr_sti.c
@@ -20,6 +20,9 @@ void vm_instr_sti(
 	// acb
 	mem_i = (p->pc + 1) % MEM_SIZE;
 	acb = a->mem[mem_i];
+	//check acb
+	if (!vm_check_acb(acb, 11))
+		print("invalid acb in sti\n");
 
 	// arg 1
 	mem_i = (mem_i + 1) % MEM_SIZE;
@@ -27,7 +30,7 @@ void vm_instr_sti(
 	src = vm_get_reg_addr(p, a->mem[mem_i]);
 	if (!src)
 	{
-		vm_advance_pc(&p->pc, 1);
+		vm_advance_pc(&p->pc, 1, a->verbosity);
 		return ;
 	}
 	mem_i = (mem_i + 1) % MEM_SIZE;

--- a/vm/src/vm_print_bytes.c
+++ b/vm/src/vm_print_bytes.c
@@ -1,0 +1,15 @@
+#include "vm.h"
+
+void	vm_print_bytes(void *memory, size_t len)
+{
+	t_byte	*bytes;
+	size_t	i;
+
+	bytes = (t_byte *)memory;
+	i = 0;
+	while (i < len)
+	{
+		print("%02x ", (unsigned int)bytes[i]);
+		i++;
+	}
+}


### PR DESCRIPTION
A bunch of small changes and fixes:

ASM:
- change ``asm_get_param_sizes`` so that direct parameter sizes will _always_ be promoted to REG_SIZE with instructions ``and``, ``or``, ``xor``, ``ld`` and ``lldi``. this might still not be 100% equivalent to how subject's asm and corewar handle parameter sizes: run ``test_diff.sh`` with ``1`` as second parameter to dump output after the first cycle, if the memory differs there then the problem lies with the asm.

VM: 
- register array: change register array to ``t_byte registers[REG_NUMBER][REG_SIZE];``, makes it adjustable with the macros and easier to handle given that values in the registers are also stored in little endian.
- ``vm_advance_pc``: add a->mem and a->verbosity as parameters so that verbosity prints for PC movements can be handled there; now also the memory that is passed over is printed in a similar fashion to what the subject corewar does, making it easier to compare and spot if differences between our and subject's behaviour come from differences in the memory that the instruction reads
- ``vm_get_arg_type``: helper function for ``vm_check_acb`` that is also called from elsewhere, so split that to its own source file
- ``vm_get_val``: rewrite of handling indirect arguments, now indirect arguments appear to work at least when testing with the ``and`` instruction
- ``vm_print_bytes``: a useful helper function, also for debugging purposes! you can print the memory in the arena, the registers or the derived values to compare that e.g. reverse_bytes produced the correct result
- ``vm_instr_aff`` and ``vm_instr_and``: fixes and updates, still a little bit work in progress

TESTS:
- small changes to ``test_diff.sh``, e.g. to make the subject corewar print the output of ``aff`` instructions
- updated test files for ``aff`` and ``and``
